### PR TITLE
feat: Add Scarab-specific IPC helpers (closes #44)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ snapshot-expect = ["expect-test"]
 sixel-image = ["image"]  # Advanced Sixel decoding
 shared-state = ["memmap2", "bincode", "serde"]  # Shared memory state access
 ipc = ["libc"]  # IPC + shared-memory helpers for split-process terminals
+scarab = ["ipc"]  # Scarab-specific IPC helpers (wraps ipc module)
 
 # Full bundle (all features)
 full = [
@@ -86,6 +87,7 @@ full = [
     "sixel-image",
     "shared-state",
     "ipc",
+    "scarab",
 ]
 
 [[example]]
@@ -160,6 +162,11 @@ path = "examples/timing_demo.rs"
 name = "ipc_daemon_test"
 path = "examples/ipc_daemon_test.rs"
 required-features = ["ipc"]
+
+[[example]]
+name = "scarab_test"
+path = "examples/scarab_test.rs"
+required-features = ["scarab"]
 
 [profile.dev]
 opt-level = 0

--- a/docs/SCARAB.md
+++ b/docs/SCARAB.md
@@ -1,0 +1,308 @@
+# Scarab Testing Guide
+
+> Testing guide for Scarab terminal emulator integration
+
+## Overview
+
+The `scarab` module provides Scarab-specific wrappers around the generic [`ipc`](./IPC.md) module, preconfigured for Scarab's default paths and protocol.
+
+Scarab uses a split architecture:
+- **scarab-daemon**: Manages the PTY, parses terminal state, exposes it via shared memory
+- **scarab** (GPU client): Renders the UI by reading from shared memory
+
+This module provides the glue to test Scarab without reimplementing IPC/shared-memory plumbing.
+
+## Quick Start
+
+### 1. Enable the Feature
+
+```toml
+[dependencies]
+ratatui-testlib = { version = "0.3", features = ["scarab"] }
+```
+
+### 2. Set Environment Variable
+
+Enable Scarab testing mode:
+
+```bash
+export SCARAB_TEST_RTL=1
+```
+
+### 3. Basic Test
+
+```rust
+use std::time::Duration;
+use ratatui_testlib::scarab::ScarabTestHarness;
+
+#[test]
+fn test_echo_command() -> Result<(), Box<dyn std::error::Error>> {
+    // Connect to running scarab-daemon using default paths
+    let mut harness = ScarabTestHarness::connect()?;
+
+    // Send input via IPC
+    harness.send_input("echo hello\n")?;
+
+    // Wait for output in shared memory grid
+    harness.wait_for_text("hello", Duration::from_secs(5))?;
+
+    // Assert grid contents
+    let grid = harness.grid_contents()?;
+    assert!(grid.contains("hello"));
+
+    Ok(())
+}
+```
+
+## Default Configuration
+
+Scarab uses these default paths:
+
+| Setting | Default Value |
+|---------|---------------|
+| Socket | `/tmp/scarab-daemon.sock` |
+| Shared memory | `/scarab_shm_v1` |
+| Image buffer | `/scarab_img_v1` |
+| Magic number | `0x5343_5241` ("SCRA") |
+| Terminal size | 80x24 |
+
+## Custom Configuration
+
+```rust
+use std::time::Duration;
+use ratatui_testlib::scarab::{ScarabTestHarness, ScarabConfig};
+
+let config = ScarabConfig::builder()
+    .socket_path("/tmp/test-scarab.sock")
+    .shm_path("/test_scarab_shm")
+    .dimensions(120, 40)
+    .prompt_patterns(vec!["$ ".to_string(), "# ".to_string()])
+    .build();
+
+let mut harness = ScarabTestHarness::with_config(config)?;
+```
+
+## Testing Patterns
+
+### Pattern 1: Wait for Shell Prompt
+
+```rust
+use std::time::Duration;
+use ratatui_testlib::scarab::ScarabTestHarness;
+
+#[test]
+fn test_with_prompt() -> Result<(), Box<dyn std::error::Error>> {
+    let mut harness = ScarabTestHarness::connect()?;
+
+    // Wait for shell prompt
+    harness.wait_for_prompt(Duration::from_secs(5))?;
+
+    // Send command
+    harness.send_input("ls -la\n")?;
+
+    // Wait for output and next prompt
+    harness.wait_for_text("total", Duration::from_secs(2))?;
+
+    Ok(())
+}
+```
+
+### Pattern 2: Test Escape Sequences
+
+```rust
+use std::time::Duration;
+use ratatui_testlib::scarab::ScarabTestHarness;
+
+#[test]
+fn test_cursor_movement() -> Result<(), Box<dyn std::error::Error>> {
+    let mut harness = ScarabTestHarness::connect()?;
+
+    // Send cursor movement
+    harness.send_input("\x1b[A")?; // Up arrow
+
+    // Verify cursor position changed
+    let (row, col) = harness.cursor_position()?;
+    println!("Cursor at row: {}, col: {}", row, col);
+
+    Ok(())
+}
+```
+
+### Pattern 3: Test Sequence of Commands
+
+```rust
+use std::time::Duration;
+use ratatui_testlib::scarab::ScarabTestHarness;
+
+#[test]
+fn test_command_sequence() -> Result<(), Box<dyn std::error::Error>> {
+    let mut harness = ScarabTestHarness::connect()?;
+
+    harness.send_input("cd /tmp && ls\n")?;
+
+    // Wait for multiple texts in order
+    harness.wait_for_sequence(&["cd /tmp", "ls"], Duration::from_secs(5))?;
+
+    Ok(())
+}
+```
+
+### Pattern 4: Test Text Disappearance
+
+```rust
+use std::time::Duration;
+use ratatui_testlib::scarab::ScarabTestHarness;
+
+#[test]
+fn test_clear_screen() -> Result<(), Box<dyn std::error::Error>> {
+    let mut harness = ScarabTestHarness::connect()?;
+
+    // Write something
+    harness.send_input("echo 'temporary text'\n")?;
+    harness.wait_for_text("temporary text", Duration::from_secs(2))?;
+
+    // Clear screen
+    harness.send_input("clear\n")?;
+
+    // Wait for text to disappear
+    harness.wait_for_text_absent("temporary text", Duration::from_secs(2))?;
+
+    Ok(())
+}
+```
+
+## API Reference
+
+### ScarabTestHarness
+
+The main test harness for Scarab testing.
+
+```rust
+impl ScarabTestHarness {
+    // Connection
+    fn is_enabled() -> bool;
+    fn connect() -> IpcResult<Self>;
+    fn with_config(config: ScarabConfig) -> IpcResult<Self>;
+
+    // Input
+    fn send_input(&mut self, text: &str) -> IpcResult<()>;
+    fn send_bytes(&mut self, bytes: &[u8]) -> IpcResult<()>;
+    fn resize(&mut self, cols: u16, rows: u16) -> IpcResult<()>;
+
+    // State
+    fn refresh(&mut self) -> IpcResult<()>;
+    fn grid_contents(&self) -> IpcResult<String>;
+    fn cursor_position(&self) -> IpcResult<(u16, u16)>;
+    fn dimensions(&self) -> (u16, u16);
+    fn contains(&self, text: &str) -> IpcResult<bool>;
+
+    // Wait helpers
+    fn wait_for_text(&mut self, text: &str, timeout: Duration) -> IpcResult<()>;
+    fn wait_for_text_absent(&mut self, text: &str, timeout: Duration) -> IpcResult<()>;
+    fn wait_for_prompt(&mut self, timeout: Duration) -> IpcResult<()>;
+    fn wait_for_sequence(&mut self, texts: &[&str], timeout: Duration) -> IpcResult<()>;
+    fn wait_for_update(&mut self, timeout: Duration) -> IpcResult<()>;
+
+    // Assertions
+    fn assert_contains(&self, text: &str) -> IpcResult<()>;
+}
+```
+
+### ScarabConfig
+
+Configuration options for the test harness.
+
+```rust
+impl ScarabConfig {
+    fn builder() -> ScarabConfigBuilder;
+}
+
+impl ScarabConfigBuilder {
+    fn socket_path(self, path: impl Into<PathBuf>) -> Self;
+    fn shm_path(self, path: impl Into<String>) -> Self;
+    fn image_shm_path(self, path: impl Into<String>) -> Self;
+    fn dimensions(self, cols: u16, rows: u16) -> Self;
+    fn connect_timeout(self, timeout: Duration) -> Self;
+    fn default_timeout(self, timeout: Duration) -> Self;
+    fn prompt_patterns(self, patterns: Vec<String>) -> Self;
+    fn add_prompt_pattern(self, pattern: impl Into<String>) -> Self;
+    fn build(self) -> ScarabConfig;
+}
+```
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+jobs:
+  test-scarab:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build scarab-daemon
+        run: cargo build --release -p scarab-daemon
+
+      - name: Start daemon
+        run: |
+          ./target/release/scarab-daemon &
+          sleep 2
+
+      - name: Run Scarab tests
+        env:
+          SCARAB_TEST_RTL: "1"
+        run: cargo test --features scarab
+```
+
+## Troubleshooting
+
+### Issue: "SCARAB_TEST_RTL environment variable not set"
+
+**Solution**: Set the environment variable:
+```bash
+export SCARAB_TEST_RTL=1
+```
+
+### Issue: Socket Not Found
+
+**Symptoms**: `IpcError::SocketNotFound`
+
+**Solutions**:
+- Verify scarab-daemon is running
+- Check socket path matches configuration:
+  ```bash
+  ls -la /tmp/scarab-daemon.sock
+  ```
+
+### Issue: Invalid Magic Number
+
+**Symptoms**: `IpcError::InvalidData` with magic mismatch
+
+**Solutions**:
+- Ensure scarab-daemon version matches
+- Scarab uses magic `0x5343_5241` ("SCRA")
+- Check for protocol version mismatches
+
+### Issue: Timeout Waiting for Text
+
+**Symptoms**: `IpcError::Timeout`
+
+**Solutions**:
+- Increase timeout duration
+- Verify daemon is processing input
+- Check shared memory is updating:
+  ```rust
+  // Check sequence number changes
+  let seq1 = harness.shared_memory().sequence_number();
+  std::thread::sleep(Duration::from_millis(100));
+  harness.refresh()?;
+  let seq2 = harness.shared_memory().sequence_number();
+  assert_ne!(seq1, seq2, "Shared memory not updating");
+  ```
+
+## Related Resources
+
+- [IPC Module Documentation](./IPC.md) - Generic IPC helpers
+- [Scarab GitHub Repository](https://github.com/raibid-labs/scarab) - Scarab terminal emulator
+- [Examples](../examples/scarab_test.rs) - Working example code

--- a/examples/scarab_test.rs
+++ b/examples/scarab_test.rs
@@ -1,0 +1,151 @@
+//! Example demonstrating Scarab-specific testing.
+//!
+//! This example shows how to use the `scarab` module to test Scarab terminal
+//! emulator integration without reimplementing IPC/shared-memory plumbing.
+//!
+//! # Prerequisites
+//!
+//! 1. A running scarab-daemon that:
+//!    - Listens on `/tmp/scarab-daemon.sock`
+//!    - Exposes terminal state via `/scarab_shm_v1`
+//!
+//! 2. Environment variable set:
+//!    ```bash
+//!    export SCARAB_TEST_RTL=1
+//!    ```
+//!
+//! # Running this example
+//!
+//! ```bash
+//! # Start scarab-daemon first
+//! scarab-daemon &
+//!
+//! # Run the example
+//! SCARAB_TEST_RTL=1 cargo run --example scarab_test --features scarab
+//! ```
+
+#[cfg(feature = "scarab")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use std::time::Duration;
+
+    use ratatui_testlib::ipc::IpcError;
+    use ratatui_testlib::scarab::{ScarabConfig, ScarabTestHarness};
+
+    println!("Scarab Test Example");
+    println!("===================\n");
+
+    // Check if Scarab testing is enabled
+    if !ScarabTestHarness::is_enabled() {
+        println!("Scarab testing is disabled.");
+        println!("Set SCARAB_TEST_RTL=1 to enable Scarab testing.\n");
+        println!("Example:");
+        println!("  SCARAB_TEST_RTL=1 cargo run --example scarab_test --features scarab\n");
+        return Ok(());
+    }
+
+    println!("Scarab testing is enabled!\n");
+
+    // Show default configuration
+    let default_config = ScarabConfig::default();
+    println!("Default Configuration:");
+    println!("  Socket: {:?}", default_config.socket_path);
+    println!("  Shared memory: {}", default_config.shm_path);
+    println!("  Image shm: {:?}", default_config.image_shm_path);
+    println!("  Dimensions: {:?}", default_config.dimensions);
+    println!("  Prompt patterns: {:?}", default_config.prompt_patterns);
+    println!();
+
+    // Try to connect to Scarab daemon
+    match ScarabTestHarness::connect() {
+        Ok(mut harness) => {
+            println!("Connected to scarab-daemon successfully!\n");
+
+            // Get terminal dimensions
+            let (cols, rows) = harness.dimensions();
+            println!("Terminal size: {}x{}", cols, rows);
+
+            // Get cursor position
+            let (row, col) = harness.cursor_position()?;
+            println!("Cursor position: row={}, col={}", row, col);
+
+            // Read initial grid contents
+            let grid = harness.grid_contents()?;
+            println!("\nInitial grid contents:");
+            println!("---");
+            for line in grid.lines().take(5) {
+                println!("{}", line);
+            }
+            if grid.lines().count() > 5 {
+                println!("... ({} more lines)", grid.lines().count() - 5);
+            }
+            println!("---\n");
+
+            // Wait for prompt
+            println!("Waiting for shell prompt...");
+            match harness.wait_for_prompt(Duration::from_secs(5)) {
+                Ok(()) => println!("Prompt detected!"),
+                Err(IpcError::Timeout(_)) => println!("Timeout waiting for prompt (continuing...)"),
+                Err(e) => println!("Error: {}", e),
+            }
+
+            // Send a test command
+            println!("\nSending test command: echo 'Hello from Scarab test!'");
+            harness.send_input("echo 'Hello from Scarab test!'\n")?;
+
+            // Wait for the output
+            println!("Waiting for output...");
+            match harness.wait_for_text("Hello from Scarab test!", Duration::from_secs(5)) {
+                Ok(()) => {
+                    println!("Output received!\n");
+
+                    // Read updated grid
+                    let grid = harness.grid_contents()?;
+                    println!("Updated grid contents:");
+                    println!("---");
+                    for line in grid.lines().take(10) {
+                        println!("{}", line);
+                    }
+                    println!("---\n");
+
+                    // Assert the output
+                    harness.assert_contains("Hello from Scarab test!")?;
+                    println!("Assertion passed!");
+                }
+                Err(IpcError::Timeout(duration)) => {
+                    println!("Timeout after {:?} waiting for output.", duration);
+                    println!("This might mean the daemon isn't processing input.\n");
+                }
+                Err(e) => {
+                    println!("Error waiting for output: {}", e);
+                }
+            }
+
+            println!("\nScarab test completed successfully!");
+        }
+        Err(IpcError::SocketNotFound(path)) => {
+            println!("Scarab daemon socket not found at: {}", path.display());
+            println!("\nMake sure scarab-daemon is running:");
+            println!("  scarab-daemon &");
+        }
+        Err(IpcError::SharedMemoryNotFound(path)) => {
+            println!("Scarab shared memory not found at: {}", path);
+            println!("\nMake sure scarab-daemon creates shared memory.");
+        }
+        Err(IpcError::InvalidData(msg)) => {
+            println!("Invalid shared memory format: {}", msg);
+            println!("\nThis may indicate a protocol version mismatch.");
+            println!("Scarab expects magic: 0x5343_5241 (\"SCRA\")");
+        }
+        Err(e) => {
+            println!("Failed to connect to Scarab daemon: {}", e);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "scarab"))]
+fn main() {
+    println!("This example requires the 'scarab' feature.");
+    println!("Run with: cargo run --example scarab_test --features scarab");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,9 @@ pub mod shared_state;
 #[cfg(feature = "ipc")]
 pub mod ipc;
 
+#[cfg(feature = "scarab")]
+pub mod scarab;
+
 #[cfg(feature = "async-tokio")]
 mod async_harness;
 
@@ -266,3 +269,6 @@ pub use ipc::{
     ControlMessage, DaemonConfig, DaemonConfigBuilder, DaemonIpcClient, DaemonTestExt,
     DaemonTestHarness, IpcError, IpcResult, ShmHeader,
 };
+
+#[cfg(feature = "scarab")]
+pub use scarab::{ScarabConfig, ScarabConfigBuilder, ScarabTestExt, ScarabTestHarness};

--- a/src/scarab.rs
+++ b/src/scarab.rs
@@ -1,0 +1,642 @@
+//! Scarab-specific IPC and shared-memory helpers.
+//!
+//! This module provides Scarab-tailored wrappers around the generic [`ipc`](crate::ipc) module,
+//! preconfigured for Scarab's default paths and protocol.
+//!
+//! # Overview
+//!
+//! Scarab uses a split architecture (daemon + GPU client) where:
+//! - **scarab-daemon** manages the PTY, parses terminal state, and exposes it via shared memory
+//! - **scarab** (GPU client) renders the UI by reading from shared memory
+//!
+//! This module provides the glue to test Scarab without reimplementing IPC/shared-memory plumbing.
+//!
+//! # Quick Start
+//!
+//! ## Enable the feature
+//!
+//! ```toml
+//! [dependencies]
+//! ratatui-testlib = { version = "0.3", features = ["scarab"] }
+//! ```
+//!
+//! ## Environment Variable
+//!
+//! Enable Scarab testing mode by setting:
+//!
+//! ```bash
+//! export SCARAB_TEST_RTL=1
+//! ```
+//!
+//! ## Basic Test Example
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "scarab")]
+//! # {
+//! use std::time::Duration;
+//! use ratatui_testlib::scarab::ScarabTestHarness;
+//!
+//! # fn test() -> Result<(), Box<dyn std::error::Error>> {
+//! // Connect to running scarab-daemon using default paths
+//! let mut harness = ScarabTestHarness::connect()?;
+//!
+//! // Send input via IPC
+//! harness.send_input("echo hello\n")?;
+//!
+//! // Wait for output in shared memory grid
+//! harness.wait_for_text("hello", Duration::from_secs(5))?;
+//!
+//! // Assert grid contents
+//! let grid = harness.grid_contents()?;
+//! assert!(grid.contains("hello"));
+//! # Ok(())
+//! # }
+//! # }
+//! ```
+//!
+//! # Default Configuration
+//!
+//! Scarab uses these default paths:
+//! - Socket: `/tmp/scarab-daemon.sock`
+//! - Shared memory: `/scarab_shm_v1`
+//! - Image buffer: `/scarab_img_v1`
+//! - Magic number: `0x5343_5241` ("SCRA")
+//!
+//! # Custom Configuration
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "scarab")]
+//! # {
+//! use std::time::Duration;
+//! use ratatui_testlib::scarab::{ScarabTestHarness, ScarabConfig};
+//!
+//! # fn test() -> Result<(), Box<dyn std::error::Error>> {
+//! let config = ScarabConfig::builder()
+//!     .socket_path("/tmp/test-scarab.sock")
+//!     .shm_path("/test_scarab_shm")
+//!     .dimensions(120, 40)
+//!     .build();
+//!
+//! let mut harness = ScarabTestHarness::with_config(config)?;
+//! # Ok(())
+//! # }
+//! # }
+//! ```
+//!
+//! # Testing Patterns
+//!
+//! ## Pattern 1: Wait for Shell Prompt
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "scarab")]
+//! # {
+//! use std::time::Duration;
+//! use ratatui_testlib::scarab::ScarabTestHarness;
+//!
+//! # fn test() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut harness = ScarabTestHarness::connect()?;
+//!
+//! // Wait for shell prompt
+//! harness.wait_for_prompt(Duration::from_secs(5))?;
+//!
+//! // Send command
+//! harness.send_input("ls -la\n")?;
+//!
+//! // Wait for output and next prompt
+//! harness.wait_for_text("total", Duration::from_secs(2))?;
+//! # Ok(())
+//! # }
+//! # }
+//! ```
+//!
+//! ## Pattern 2: Test Escape Sequences
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "scarab")]
+//! # {
+//! use std::time::Duration;
+//! use ratatui_testlib::scarab::ScarabTestHarness;
+//!
+//! # fn test() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut harness = ScarabTestHarness::connect()?;
+//!
+//! // Send cursor movement
+//! harness.send_input("\x1b[A")?; // Up arrow
+//!
+//! // Verify cursor position changed
+//! let (row, _col) = harness.cursor_position()?;
+//! println!("Cursor at row: {}", row);
+//! # Ok(())
+//! # }
+//! # }
+//! ```
+
+use std::{
+    path::PathBuf,
+    time::Duration,
+};
+
+use crate::ipc::{DaemonIpcClient, DaemonSharedMemory, IpcError, IpcResult};
+
+// Scarab-specific defaults
+const SCARAB_SOCKET_PATH: &str = "/tmp/scarab-daemon.sock";
+const SCARAB_SHM_PATH: &str = "/scarab_shm_v1";
+const SCARAB_IMAGE_SHM_PATH: &str = "/scarab_img_v1";
+const SCARAB_MAGIC: u32 = 0x5343_5241; // "SCRA"
+const SCARAB_VERSION: u32 = 1;
+
+/// Scarab-specific configuration.
+///
+/// Preconfigured with Scarab's default paths and protocol settings.
+#[derive(Debug, Clone)]
+pub struct ScarabConfig {
+    /// Path to the Unix socket for IPC.
+    pub socket_path: PathBuf,
+
+    /// Path to the shared memory segment for terminal state.
+    pub shm_path: String,
+
+    /// Path to the shared memory segment for image buffer.
+    pub image_shm_path: Option<String>,
+
+    /// Terminal dimensions (cols, rows).
+    pub dimensions: Option<(u16, u16)>,
+
+    /// Connection timeout.
+    pub connect_timeout: Duration,
+
+    /// Default timeout for wait operations.
+    pub default_timeout: Duration,
+
+    /// Prompt patterns to detect (e.g., "$", "#", ">").
+    pub prompt_patterns: Vec<String>,
+}
+
+impl Default for ScarabConfig {
+    fn default() -> Self {
+        Self {
+            socket_path: PathBuf::from(SCARAB_SOCKET_PATH),
+            shm_path: SCARAB_SHM_PATH.to_string(),
+            image_shm_path: Some(SCARAB_IMAGE_SHM_PATH.to_string()),
+            dimensions: Some((80, 24)),
+            connect_timeout: Duration::from_secs(5),
+            default_timeout: Duration::from_secs(10),
+            prompt_patterns: vec![
+                "$ ".to_string(),
+                "# ".to_string(),
+                "> ".to_string(),
+            ],
+        }
+    }
+}
+
+impl ScarabConfig {
+    /// Create a new configuration builder.
+    pub fn builder() -> ScarabConfigBuilder {
+        ScarabConfigBuilder::default()
+    }
+
+}
+
+/// Builder for ScarabConfig.
+#[derive(Debug, Default)]
+pub struct ScarabConfigBuilder {
+    config: ScarabConfig,
+}
+
+impl ScarabConfigBuilder {
+    /// Set the Unix socket path.
+    pub fn socket_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.config.socket_path = path.into();
+        self
+    }
+
+    /// Set the shared memory path.
+    pub fn shm_path(mut self, path: impl Into<String>) -> Self {
+        self.config.shm_path = path.into();
+        self
+    }
+
+    /// Set the image shared memory path.
+    pub fn image_shm_path(mut self, path: impl Into<String>) -> Self {
+        self.config.image_shm_path = Some(path.into());
+        self
+    }
+
+    /// Set terminal dimensions.
+    pub fn dimensions(mut self, cols: u16, rows: u16) -> Self {
+        self.config.dimensions = Some((cols, rows));
+        self
+    }
+
+    /// Set connection timeout.
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.config.connect_timeout = timeout;
+        self
+    }
+
+    /// Set default wait timeout.
+    pub fn default_timeout(mut self, timeout: Duration) -> Self {
+        self.config.default_timeout = timeout;
+        self
+    }
+
+    /// Set prompt patterns.
+    pub fn prompt_patterns(mut self, patterns: Vec<String>) -> Self {
+        self.config.prompt_patterns = patterns;
+        self
+    }
+
+    /// Add a prompt pattern.
+    pub fn add_prompt_pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.config.prompt_patterns.push(pattern.into());
+        self
+    }
+
+    /// Build the configuration.
+    pub fn build(self) -> ScarabConfig {
+        self.config
+    }
+}
+
+/// Scarab-specific shared memory reader.
+///
+/// Wraps [`DaemonSharedMemory`] with Scarab's magic number and version validation.
+#[cfg(target_family = "unix")]
+pub struct ScarabSharedMemory {
+    inner: DaemonSharedMemory,
+}
+
+#[cfg(target_family = "unix")]
+impl std::fmt::Debug for ScarabSharedMemory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScarabSharedMemory")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+#[cfg(target_family = "unix")]
+impl ScarabSharedMemory {
+    /// Open Scarab shared memory with protocol validation.
+    pub fn open(shm_path: &str) -> IpcResult<Self> {
+        let inner = DaemonSharedMemory::open_with_validation(
+            shm_path,
+            SCARAB_MAGIC,
+            SCARAB_VERSION,
+        )?;
+        Ok(Self { inner })
+    }
+
+    /// Refresh the header from shared memory.
+    pub fn refresh(&mut self) -> IpcResult<()> {
+        self.inner.refresh()
+    }
+
+    /// Get the terminal dimensions (cols, rows).
+    pub fn dimensions(&self) -> (u16, u16) {
+        self.inner.dimensions()
+    }
+
+    /// Get the cursor position (row, col).
+    pub fn cursor_position(&self) -> (u16, u16) {
+        self.inner.cursor_position()
+    }
+
+    /// Get the sequence number for change detection.
+    pub fn sequence_number(&self) -> u32 {
+        self.inner.sequence_number()
+    }
+
+    /// Read the terminal grid as a string.
+    pub fn grid_contents(&self) -> IpcResult<String> {
+        self.inner.grid_contents()
+    }
+
+    /// Check if the grid contains the given text.
+    pub fn contains(&self, text: &str) -> IpcResult<bool> {
+        self.inner.contains(text)
+    }
+
+    /// Get a specific cell character at (row, col).
+    pub fn cell_at(&self, row: u16, col: u16) -> IpcResult<char> {
+        self.inner.cell_at(row, col)
+    }
+}
+
+/// Scarab test harness for integration testing.
+///
+/// Combines IPC communication and shared memory reading into a single
+/// ergonomic API tailored for Scarab testing.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # #[cfg(feature = "scarab")]
+/// # {
+/// use std::time::Duration;
+/// use ratatui_testlib::scarab::ScarabTestHarness;
+///
+/// # fn test() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut harness = ScarabTestHarness::connect()?;
+///
+/// // Send a command
+/// harness.send_input("echo 'Hello, Scarab!'\n")?;
+///
+/// // Wait for output
+/// harness.wait_for_text("Hello, Scarab!", Duration::from_secs(5))?;
+/// # Ok(())
+/// # }
+/// # }
+/// ```
+#[cfg(target_family = "unix")]
+#[derive(Debug)]
+pub struct ScarabTestHarness {
+    ipc: DaemonIpcClient,
+    shm: ScarabSharedMemory,
+    config: ScarabConfig,
+}
+
+#[cfg(target_family = "unix")]
+impl ScarabTestHarness {
+    /// Check if Scarab testing is enabled via environment variable.
+    pub fn is_enabled() -> bool {
+        std::env::var("SCARAB_TEST_RTL").is_ok()
+    }
+
+    /// Connect to a running Scarab daemon using default configuration.
+    ///
+    /// Requires `SCARAB_TEST_RTL=1` environment variable to be set.
+    pub fn connect() -> IpcResult<Self> {
+        if !Self::is_enabled() {
+            return Err(IpcError::TestingDisabled);
+        }
+        Self::with_config(ScarabConfig::default())
+    }
+
+    /// Create a harness with custom configuration.
+    pub fn with_config(config: ScarabConfig) -> IpcResult<Self> {
+        // Connect to IPC socket
+        let ipc = DaemonIpcClient::connect(&config.socket_path)?;
+
+        // Open shared memory with Scarab-specific validation
+        let shm = ScarabSharedMemory::open(&config.shm_path)?;
+
+        Ok(Self { ipc, shm, config })
+    }
+
+    /// Send input text to the PTY via IPC.
+    pub fn send_input(&mut self, text: &str) -> IpcResult<()> {
+        self.ipc.send_text(text)
+    }
+
+    /// Send raw bytes to the PTY via IPC.
+    pub fn send_bytes(&mut self, bytes: &[u8]) -> IpcResult<()> {
+        self.ipc.send_input(bytes)
+    }
+
+    /// Resize the terminal.
+    pub fn resize(&mut self, cols: u16, rows: u16) -> IpcResult<()> {
+        self.ipc.resize(cols, rows)
+    }
+
+    /// Request a state refresh from the daemon.
+    pub fn refresh(&mut self) -> IpcResult<()> {
+        self.ipc.refresh()?;
+        self.shm.refresh()
+    }
+
+    /// Get the current grid contents as a string.
+    pub fn grid_contents(&self) -> IpcResult<String> {
+        self.shm.grid_contents()
+    }
+
+    /// Get the current cursor position (row, col).
+    pub fn cursor_position(&self) -> IpcResult<(u16, u16)> {
+        Ok(self.shm.cursor_position())
+    }
+
+    /// Get the terminal dimensions (cols, rows).
+    pub fn dimensions(&self) -> (u16, u16) {
+        self.shm.dimensions()
+    }
+
+    /// Check if the grid contains the given text.
+    pub fn contains(&self, text: &str) -> IpcResult<bool> {
+        self.shm.contains(text)
+    }
+
+    /// Wait until the grid contains the specified text.
+    pub fn wait_for_text(&mut self, text: &str, timeout: Duration) -> IpcResult<()> {
+        let start = std::time::Instant::now();
+        let poll_interval = Duration::from_millis(50);
+
+        loop {
+            self.shm.refresh()?;
+
+            if self.shm.contains(text)? {
+                return Ok(());
+            }
+
+            if start.elapsed() >= timeout {
+                return Err(IpcError::Timeout(timeout));
+            }
+
+            std::thread::sleep(poll_interval);
+        }
+    }
+
+    /// Wait until the grid does NOT contain the specified text.
+    pub fn wait_for_text_absent(&mut self, text: &str, timeout: Duration) -> IpcResult<()> {
+        let start = std::time::Instant::now();
+        let poll_interval = Duration::from_millis(50);
+
+        loop {
+            self.shm.refresh()?;
+
+            if !self.shm.contains(text)? {
+                return Ok(());
+            }
+
+            if start.elapsed() >= timeout {
+                return Err(IpcError::Timeout(timeout));
+            }
+
+            std::thread::sleep(poll_interval);
+        }
+    }
+
+    /// Wait for a shell prompt to appear.
+    ///
+    /// Uses the configured prompt patterns (default: `$`, `#`, `>`).
+    pub fn wait_for_prompt(&mut self, timeout: Duration) -> IpcResult<()> {
+        let start = std::time::Instant::now();
+        let poll_interval = Duration::from_millis(50);
+        let patterns = self.config.prompt_patterns.clone();
+
+        loop {
+            self.shm.refresh()?;
+            let grid = self.shm.grid_contents()?;
+
+            for pattern in &patterns {
+                if grid.contains(pattern) {
+                    return Ok(());
+                }
+            }
+
+            if start.elapsed() >= timeout {
+                return Err(IpcError::Timeout(timeout));
+            }
+
+            std::thread::sleep(poll_interval);
+        }
+    }
+
+    /// Wait for a sequence of text strings to appear in order.
+    pub fn wait_for_sequence(&mut self, texts: &[&str], timeout: Duration) -> IpcResult<()> {
+        let start = std::time::Instant::now();
+
+        for text in texts {
+            let remaining = timeout.saturating_sub(start.elapsed());
+            if remaining.is_zero() {
+                return Err(IpcError::Timeout(timeout));
+            }
+            self.wait_for_text(text, remaining)?;
+        }
+
+        Ok(())
+    }
+
+    /// Wait for the sequence number to change, indicating a state update.
+    pub fn wait_for_update(&mut self, timeout: Duration) -> IpcResult<()> {
+        let start = std::time::Instant::now();
+        let poll_interval = Duration::from_millis(10);
+        let initial_seq = self.shm.sequence_number();
+
+        loop {
+            self.shm.refresh()?;
+
+            if self.shm.sequence_number() != initial_seq {
+                return Ok(());
+            }
+
+            if start.elapsed() >= timeout {
+                return Err(IpcError::Timeout(timeout));
+            }
+
+            std::thread::sleep(poll_interval);
+        }
+    }
+
+    /// Assert that the grid contains the expected text.
+    pub fn assert_contains(&self, text: &str) -> IpcResult<()> {
+        if self.shm.contains(text)? {
+            Ok(())
+        } else {
+            Err(IpcError::InvalidData(format!(
+                "Expected grid to contain '{}', but it didn't.\nGrid:\n{}",
+                text,
+                self.shm.grid_contents().unwrap_or_default()
+            )))
+        }
+    }
+
+    /// Get the default timeout from configuration.
+    pub fn default_timeout(&self) -> Duration {
+        self.config.default_timeout
+    }
+
+    /// Get a reference to the underlying shared memory reader.
+    pub fn shared_memory(&self) -> &ScarabSharedMemory {
+        &self.shm
+    }
+}
+
+/// Extension trait for integrating Scarab testing with TuiTestHarness.
+pub trait ScarabTestExt {
+    /// Connect to a Scarab daemon for testing.
+    fn connect_scarab(&self) -> IpcResult<ScarabTestHarness>;
+
+    /// Connect to a Scarab daemon with custom configuration.
+    fn connect_scarab_with_config(&self, config: ScarabConfig) -> IpcResult<ScarabTestHarness>;
+
+    /// Check if Scarab testing mode is enabled.
+    fn scarab_enabled(&self) -> bool;
+}
+
+impl ScarabTestExt for crate::TuiTestHarness {
+    fn connect_scarab(&self) -> IpcResult<ScarabTestHarness> {
+        ScarabTestHarness::connect()
+    }
+
+    fn connect_scarab_with_config(&self, config: ScarabConfig) -> IpcResult<ScarabTestHarness> {
+        ScarabTestHarness::with_config(config)
+    }
+
+    fn scarab_enabled(&self) -> bool {
+        ScarabTestHarness::is_enabled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = ScarabConfig::default();
+
+        assert_eq!(config.socket_path, PathBuf::from("/tmp/scarab-daemon.sock"));
+        assert_eq!(config.shm_path, "/scarab_shm_v1");
+        assert_eq!(config.image_shm_path, Some("/scarab_img_v1".to_string()));
+        assert_eq!(config.dimensions, Some((80, 24)));
+        assert!(!config.prompt_patterns.is_empty());
+    }
+
+    #[test]
+    fn test_config_builder() {
+        let config = ScarabConfig::builder()
+            .socket_path("/custom/socket.sock")
+            .shm_path("/custom_shm")
+            .dimensions(120, 40)
+            .prompt_patterns(vec![">>> ".to_string()])
+            .build();
+
+        assert_eq!(config.socket_path, PathBuf::from("/custom/socket.sock"));
+        assert_eq!(config.shm_path, "/custom_shm");
+        assert_eq!(config.dimensions, Some((120, 40)));
+        assert_eq!(config.prompt_patterns, vec![">>> ".to_string()]);
+    }
+
+    #[test]
+    fn test_add_prompt_pattern() {
+        let config = ScarabConfig::builder()
+            .add_prompt_pattern(">>> ")
+            .add_prompt_pattern("... ")
+            .build();
+
+        // Default patterns plus two new ones
+        assert!(config.prompt_patterns.len() >= 2);
+        assert!(config.prompt_patterns.contains(&">>> ".to_string()));
+        assert!(config.prompt_patterns.contains(&"... ".to_string()));
+    }
+
+    #[test]
+    fn test_is_enabled_without_env() {
+        std::env::remove_var("SCARAB_TEST_RTL");
+        assert!(!ScarabTestHarness::is_enabled());
+    }
+
+    #[test]
+    fn test_is_enabled_with_env() {
+        std::env::set_var("SCARAB_TEST_RTL", "1");
+        assert!(ScarabTestHarness::is_enabled());
+        std::env::remove_var("SCARAB_TEST_RTL");
+    }
+
+    #[test]
+    fn test_scarab_magic_constants() {
+        assert_eq!(SCARAB_MAGIC, 0x5343_5241);
+        assert_eq!(SCARAB_VERSION, 1);
+    }
+}

--- a/tests/scarab_test.rs
+++ b/tests/scarab_test.rs
@@ -1,0 +1,236 @@
+//! Integration tests for the Scarab module.
+//!
+//! These tests verify the Scarab-specific testing functionality.
+//! Most tests are unit tests in the module itself; integration tests
+//! that require a running daemon are marked with `#[ignore]`.
+
+#[cfg(all(feature = "scarab", target_family = "unix"))]
+mod scarab_tests {
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    use ratatui_testlib::scarab::{ScarabConfig, ScarabTestHarness};
+
+    #[test]
+    fn test_default_config_values() {
+        let config = ScarabConfig::default();
+
+        assert_eq!(config.socket_path, PathBuf::from("/tmp/scarab-daemon.sock"));
+        assert_eq!(config.shm_path, "/scarab_shm_v1");
+        assert_eq!(config.image_shm_path, Some("/scarab_img_v1".to_string()));
+        assert_eq!(config.dimensions, Some((80, 24)));
+        assert_eq!(config.connect_timeout, Duration::from_secs(5));
+        assert_eq!(config.default_timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_default_prompt_patterns() {
+        let config = ScarabConfig::default();
+
+        assert!(config.prompt_patterns.contains(&"$ ".to_string()));
+        assert!(config.prompt_patterns.contains(&"# ".to_string()));
+        assert!(config.prompt_patterns.contains(&"> ".to_string()));
+    }
+
+    #[test]
+    fn test_config_builder_socket_path() {
+        let config = ScarabConfig::builder()
+            .socket_path("/custom/scarab.sock")
+            .build();
+
+        assert_eq!(config.socket_path, PathBuf::from("/custom/scarab.sock"));
+    }
+
+    #[test]
+    fn test_config_builder_shm_path() {
+        let config = ScarabConfig::builder()
+            .shm_path("/custom_shm")
+            .build();
+
+        assert_eq!(config.shm_path, "/custom_shm");
+    }
+
+    #[test]
+    fn test_config_builder_image_shm_path() {
+        let config = ScarabConfig::builder()
+            .image_shm_path("/custom_img_shm")
+            .build();
+
+        assert_eq!(config.image_shm_path, Some("/custom_img_shm".to_string()));
+    }
+
+    #[test]
+    fn test_config_builder_dimensions() {
+        let config = ScarabConfig::builder()
+            .dimensions(120, 40)
+            .build();
+
+        assert_eq!(config.dimensions, Some((120, 40)));
+    }
+
+    #[test]
+    fn test_config_builder_timeouts() {
+        let config = ScarabConfig::builder()
+            .connect_timeout(Duration::from_secs(15))
+            .default_timeout(Duration::from_secs(30))
+            .build();
+
+        assert_eq!(config.connect_timeout, Duration::from_secs(15));
+        assert_eq!(config.default_timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_config_builder_prompt_patterns() {
+        let config = ScarabConfig::builder()
+            .prompt_patterns(vec![">>> ".to_string(), "... ".to_string()])
+            .build();
+
+        assert_eq!(config.prompt_patterns.len(), 2);
+        assert!(config.prompt_patterns.contains(&">>> ".to_string()));
+        assert!(config.prompt_patterns.contains(&"... ".to_string()));
+    }
+
+    #[test]
+    fn test_config_builder_add_prompt_pattern() {
+        let config = ScarabConfig::builder()
+            .add_prompt_pattern("custom> ")
+            .build();
+
+        // Should have default patterns plus the custom one
+        assert!(config.prompt_patterns.contains(&"custom> ".to_string()));
+        // Default patterns should still be there
+        assert!(config.prompt_patterns.contains(&"$ ".to_string()));
+    }
+
+    #[test]
+    fn test_config_builder_chaining() {
+        let config = ScarabConfig::builder()
+            .socket_path("/test.sock")
+            .shm_path("/test_shm")
+            .dimensions(100, 30)
+            .connect_timeout(Duration::from_secs(20))
+            .default_timeout(Duration::from_secs(60))
+            .add_prompt_pattern("test> ")
+            .build();
+
+        assert_eq!(config.socket_path, PathBuf::from("/test.sock"));
+        assert_eq!(config.shm_path, "/test_shm");
+        assert_eq!(config.dimensions, Some((100, 30)));
+        assert_eq!(config.connect_timeout, Duration::from_secs(20));
+        assert_eq!(config.default_timeout, Duration::from_secs(60));
+        assert!(config.prompt_patterns.contains(&"test> ".to_string()));
+    }
+
+    #[test]
+    fn test_is_enabled_without_env() {
+        std::env::remove_var("SCARAB_TEST_RTL");
+        assert!(!ScarabTestHarness::is_enabled());
+    }
+
+    #[test]
+    fn test_is_enabled_with_env() {
+        std::env::set_var("SCARAB_TEST_RTL", "1");
+        assert!(ScarabTestHarness::is_enabled());
+        std::env::remove_var("SCARAB_TEST_RTL");
+    }
+
+    #[test]
+    fn test_is_enabled_with_any_value() {
+        std::env::set_var("SCARAB_TEST_RTL", "yes");
+        assert!(ScarabTestHarness::is_enabled());
+        std::env::remove_var("SCARAB_TEST_RTL");
+
+        std::env::set_var("SCARAB_TEST_RTL", "true");
+        assert!(ScarabTestHarness::is_enabled());
+        std::env::remove_var("SCARAB_TEST_RTL");
+
+        std::env::set_var("SCARAB_TEST_RTL", "0");
+        assert!(ScarabTestHarness::is_enabled()); // Any value counts as enabled
+        std::env::remove_var("SCARAB_TEST_RTL");
+    }
+
+    // Integration tests that require a running scarab-daemon
+    #[test]
+    #[ignore = "requires running scarab-daemon - run with SCARAB_TEST_RTL=1"]
+    fn test_scarab_connection() {
+        if !ScarabTestHarness::is_enabled() {
+            return;
+        }
+
+        let result = ScarabTestHarness::connect();
+
+        match result {
+            Ok(harness) => {
+                let (cols, rows) = harness.dimensions();
+                assert!(cols > 0, "Terminal width should be positive");
+                assert!(rows > 0, "Terminal height should be positive");
+            }
+            Err(e) => {
+                println!("Expected error (daemon not running): {}", e);
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "requires running scarab-daemon - run with SCARAB_TEST_RTL=1"]
+    fn test_scarab_send_and_receive() {
+        if !ScarabTestHarness::is_enabled() {
+            return;
+        }
+
+        let mut harness = match ScarabTestHarness::connect() {
+            Ok(h) => h,
+            Err(_) => return,
+        };
+
+        // Send a simple echo command
+        harness.send_input("echo scarab_test_marker_xyz\n").unwrap();
+
+        // Wait for the output
+        harness
+            .wait_for_text("scarab_test_marker_xyz", Duration::from_secs(5))
+            .unwrap();
+
+        // Verify grid contains the marker
+        assert!(harness.contains("scarab_test_marker_xyz").unwrap());
+    }
+
+    #[test]
+    #[ignore = "requires running scarab-daemon - run with SCARAB_TEST_RTL=1"]
+    fn test_scarab_cursor_position() {
+        if !ScarabTestHarness::is_enabled() {
+            return;
+        }
+
+        let harness = match ScarabTestHarness::connect() {
+            Ok(h) => h,
+            Err(_) => return,
+        };
+
+        let (row, col) = harness.cursor_position().unwrap();
+
+        // Cursor should be within terminal bounds
+        let (cols, rows) = harness.dimensions();
+        assert!(col < cols, "Cursor column should be within bounds");
+        assert!(row < rows, "Cursor row should be within bounds");
+    }
+
+    #[test]
+    #[ignore = "requires running scarab-daemon - run with SCARAB_TEST_RTL=1"]
+    fn test_scarab_wait_for_prompt() {
+        if !ScarabTestHarness::is_enabled() {
+            return;
+        }
+
+        let mut harness = match ScarabTestHarness::connect() {
+            Ok(h) => h,
+            Err(_) => return,
+        };
+
+        // Wait for a shell prompt
+        let result = harness.wait_for_prompt(Duration::from_secs(5));
+
+        // This should succeed if a shell is running
+        assert!(result.is_ok() || result.is_err(), "Should return a result");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `scarab` module wrapping the generic `ipc` module with Scarab-specific defaults
- Provides `ScarabTestHarness` with preconfigured socket path (`/tmp/scarab-daemon.sock`), shared memory (`/scarab_shm_v1`), and magic number (`0x5343_5241`)
- Adds `wait_for_prompt()` helper with configurable prompt patterns
- Includes comprehensive documentation in `docs/SCARAB.md`

## Test plan
- [x] Unit tests pass (`cargo test --features scarab`)
- [ ] Integration tests work with running scarab-daemon (manual verification)
- [x] Documentation builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)