### PR TITLE
chore: Prepare release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-12-06
+
+### Added
+- Scarab-specific IPC helpers (#44)
+  - New `scarab` module wrapping generic `ipc` module with Scarab defaults
+  - `ScarabTestHarness` for testing Scarab terminal emulator
+  - `ScarabConfig` builder with Scarab-specific defaults:
+    - Socket: `/tmp/scarab-daemon.sock`
+    - Shared memory: `/scarab_shm_v1`
+    - Image buffer: `/scarab_img_v1`
+    - Magic number: `0x5343_5241` ("SCRA")
+  - `wait_for_prompt()` with configurable prompt patterns
+  - `ScarabTestExt` trait for TuiTestHarness integration
+  - `SCARAB_TEST_RTL` environment variable for enabling tests
+  - Documentation at `docs/SCARAB.md`
+  - Example at `examples/scarab_test.rs`
+  - Integration tests at `tests/scarab_test.rs`
+
+### Features
+- `scarab`: Scarab-specific IPC helpers (depends on `ipc` feature)
+
 ## [0.3.0] - 2025-12-06
 
 ### Added
@@ -93,7 +114,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Issue #7: Add public API for headless/stream-based parsing - Implemented via `ScreenState::feed()`
 - Issue #8: Expose Screen/Grid state for verification - Implemented via `get_cell()` and public `Cell` struct
 
-[Unreleased]: https://github.com/raibid-labs/ratatui-testlib/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/raibid-labs/ratatui-testlib/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/raibid-labs/ratatui-testlib/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/raibid-labs/ratatui-testlib/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/raibid-labs/ratatui-testlib/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/raibid-labs/ratatui-testlib/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-testlib"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Raibid Labs"]


### PR DESCRIPTION
## Summary
- Bumps version to v0.4.0
- Updates CHANGELOG with Scarab module additions from #44

## Changes in v0.4.0
- Scarab-specific IPC helpers (`scarab` feature)
- `ScarabTestHarness` with Scarab defaults
- `ScarabConfig` builder
- `wait_for_prompt()` helper
- Documentation at `docs/SCARAB.md`

## Test plan
- [x] Version updated in Cargo.toml
- [x] CHANGELOG updated with v0.4.0 section
- [x] All links updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)